### PR TITLE
feat: Add verify parameter to cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1080,7 +1079,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2643,7 +2641,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4553,7 +4550,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5447,7 +5443,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7758,7 +7753,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8749,7 +8743,6 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -9914,7 +9907,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10081,7 +10073,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface PrMirrorOptions {
   org: string;
   repo: string;
   sync: boolean;
+  verify: boolean;
 }
 
 export interface GitHubAuth {

--- a/test/createpr.test.ts
+++ b/test/createpr.test.ts
@@ -10,7 +10,7 @@ import { exec, execVerbose, getMirrorRepoPath } from '../src/utils';
 describe('createPr', () => {
   it('creates PR using gh with correct args', () => {
     createPr(
-      { base: 'main', number: 42, org: 'Org', repo: 'Repo', sync: false },
+      { base: 'main', number: 42, org: 'Org', repo: 'Repo', sync: false, verify: false },
       { token: 'token', username: 'someuser' }
     );
 

--- a/test/mirror.test.ts
+++ b/test/mirror.test.ts
@@ -9,7 +9,7 @@ import { execVerbose, cleanupMirrorRepo, getMirrorRepoPath } from '../src/utils'
 
 describe('mirror', () => {
   it('runs expected git commands', () => {
-    mirror({ base: 'main', number: 42, org: 'Org', repo: 'Repo', sync: false });
+    mirror({ base: 'main', number: 42, org: 'Org', repo: 'Repo', sync: false, verify: false });
 
     expect(cleanupMirrorRepo).toHaveBeenCalledTimes(1);
     expect(getMirrorRepoPath).toHaveBeenCalledTimes(1);

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -9,7 +9,7 @@ import { execVerbose, cleanupMirrorRepo, getMirrorRepoPath } from '../src/utils'
 
 describe('sync', () => {
   it('runs expected git commands', () => {
-    sync({ base: 'main', number: 7, org: 'Org', repo: 'Repo', sync: true });
+    sync({ base: 'main', number: 7, org: 'Org', repo: 'Repo', sync: true, verify: false });
 
     expect(cleanupMirrorRepo).toHaveBeenCalledTimes(1);
     expect(getMirrorRepoPath).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Description

This pull request adds a new `--verify` option to the `prmirror` CLI tool, allowing users to review and confirm all resolved input parameters before proceeding. This change improves safety by preventing accidental operations with unintended arguments. The implementation includes updates to both the main code and the test suite to support and verify this new feature.

**New verification feature:**

* Added a `--verify` (`-v`) boolean CLI option to prompt the user to confirm all resolved inputs before proceeding. If the user does not confirm, the process exits without making changes. (`src/prmirror.ts`, `src/types.ts`) [[1]](diffhunk://#diff-7315ba28c247975c967c6e7419d6669caeacfb34bde6cf090805490f8ba405f1R26) [[2]](diffhunk://#diff-7315ba28c247975c967c6e7419d6669caeacfb34bde6cf090805490f8ba405f1R130-R135) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR7)
* Implemented the `verifyOptionsOrExit` async function, which displays the resolved options and asks for user confirmation via the command line. (`src/prmirror.ts`)
* Integrated the verification step into the main `prMirror` workflow, so it runs after parsing and validating options. (`src/prmirror.ts`)

**Test suite updates:**

* Updated all relevant tests and mocks to include the new `verify` option in the `PrMirrorOptions` object. (`test/createpr.test.ts`, `test/mirror.test.ts`, `test/sync.test.ts`, `test/prmirror.test.ts`) [[1]](diffhunk://#diff-fecd5a2ce833b2d5b511483dfb1f5807f7037466fbdfeb5bd65cae660b7b0755L13-R13) [[2]](diffhunk://#diff-232175d5aed293f0f56cd5fdb3a99206306b69fcfd704d46b2cf2f75826ac088L12-R12) [[3]](diffhunk://#diff-ac6389013bbbb75d49e2e461cc4d02932888733967636dfb5b09d19c9bd0dfb3L12-R12) [[4]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR140) [[5]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR156) [[6]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebL138-R190) [[7]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR213) [[8]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR235) [[9]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR258) [[10]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR280) [[11]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR302) [[12]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR323) [[13]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebR334) [[14]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebL286-R345) [[15]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebL305-R364) [[16]](diffhunk://#diff-dedb5d68f170e99a9dbcc1b901a4c3b2808758b37f5717d4ddab8442a2f172ebL324-R383)
* Added new tests to ensure that the process aborts if the user does not confirm, and proceeds only when confirmation is received. (`test/prmirror.test.ts`)
* Mocked the readline interface in tests to simulate user input for the verification prompt. (`test/prmirror.test.ts`)

## Related Issue(s)

Fixes #4