### PR TITLE
chore: Update access token

### DIFF
--- a/.github/workflows/302-flow-publish-release.yaml
+++ b/.github/workflows/302-flow-publish-release.yaml
@@ -168,7 +168,7 @@ jobs:
           if [[ -d "dist" ]]; then
             ls -l dist
           fi
-      
+
       - name: Publish to npm
         run: |
           echo "::group::View Version to publish to npm"


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow file `.github/workflows/302-flow-publish-release.yaml` to consistently use the `GH_ACCESS_TOKEN` secret instead of the default `GITHUB_TOKEN` for authentication and publishing steps. This change likely improves permissions management or aligns with updated security practices.

Authentication and token usage updates:

* Updated all workflow steps to use `GH_ACCESS_TOKEN` (referenced as `${{ secrets.GH_ACCESS_TOKEN }}`) instead of the default `GITHUB_TOKEN` for `checkout-token`, `GITHUB_TOKEN`, and `GH_TOKEN` environment variables. This affects steps for checking out code, calculating the next version, and publishing releases. [[1]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L37-R37) [[2]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L51-R51) [[3]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L100-R100) [[4]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L153-R154)

## Related Issue(s)

Relates to #8