### PR TITLE
fix(build): Fix output directory for npm pack

### DIFF
--- a/.github/workflows/302-flow-publish-release.yaml
+++ b/.github/workflows/302-flow-publish-release.yaml
@@ -238,7 +238,7 @@ jobs:
               echo "::notice file=302-flow-publish-release.yaml,line=237::Package is created"
             else
               PROCEED="false"
-              echo "::error file=302-flow-publish-release.yaml,line=240::Package is not created"
+              echo "::error file=302-flow-publish-release.yaml,line=237::Package is not created"
               echo "Attempt Manual Publish!"
             fi
           echo "::endgroup::"


### PR DESCRIPTION
## Description

This pull request makes minor improvements to the release workflow by ensuring the output directory exists before packaging and updating line references in workflow notices and errors.

- Workflow reliability:
  * Added a step to create the `output` directory before running `npm pack` to prevent errors if the directory does not exist.

- Maintenance and clarity:
  * Updated line numbers in workflow `echo` statements for notices and errors to reflect the latest script changes.

## Related Issue(s)

#8 