### PR TITLE
fix(bug-ci): Fix workflow fails when semantic release passes with no new version

### DIFF
--- a/.github/workflows/302-flow-publish-release.yaml
+++ b/.github/workflows/302-flow-publish-release.yaml
@@ -64,13 +64,13 @@ jobs:
           if [[ "${{ github.event.repository.default_branch }}" == "${{ github.ref_name }}" ]]; then
             if SEMREL_OUTPUT=$(npx semantic-release --dry-run 2>&1); then
               if echo "${SEMREL_OUTPUT}" | grep -q "The next release version is"; then
-                echo "::notice file=302-flow-publish-release.yaml,line=65::Semantic Release detected a new version"
+                echo "::notice file=302-flow-publish-release.yaml::Semantic Release detected a new version"
               else
-                echo "::notice file=302-flow-publish-release.yaml,line=65::Semantic Release detected NO new version"
+                echo "::notice file=302-flow-publish-release.yaml::Semantic Release detected NO new version"
                 PROCEED="false"
               fi
             else
-              echo "::notice file=302-flow-publish-release.yaml,line=65::Semantic Release did NOT run successfully"
+              echo "::notice file=302-flow-publish-release.yaml::Semantic Release did NOT run successfully"
               PROCEED="false"
             fi
           else
@@ -250,10 +250,10 @@ jobs:
           PROCEED="true"
           echo "::group::Verify Package is Created"
             if ls -l output | grep "${{ needs.get-package-info.outputs.package-name }}" > /dev/null 2>&1 ; then
-              echo "::notice file=302-flow-publish-release.yaml,line=237::Package is created"
+              echo "::notice file=302-flow-publish-release.yaml::Package is created"
             else
               PROCEED="false"
-              echo "::error file=302-flow-publish-release.yaml,line=237::Package is not created"
+              echo "::error file=302-flow-publish-release.yaml::Package is not created"
               echo "Attempt Manual Publish!"
             fi
           echo "::endgroup::"


### PR DESCRIPTION
## Description

This pull request updates the release workflow in `.github/workflows/302-flow-publish-release.yaml` to improve the detection and handling of release versions, as well as to streamline output management. The main focus is on making the release process more robust and accurate by refining how release conditions and version extraction are handled.

**Release detection and output management improvements:**

* Changed the workflow to use the `set-outputs` step for setting `version` and `need-release` outputs, replacing the previous `tag` and `calculate-version` steps for more consistent output management. [[1]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L30-R31) [[2]](diffhunk://#diff-a054f94b1c01620ed2cd35cdee2cb3a845ace6ae2cd5030474a737d7804645a2L83-R105)
* Enhanced the semantic-release check by parsing its output for the phrase "The next release version is", providing more reliable detection of whether a new release is needed and adding clearer logging for each outcome.
* Updated the version extraction logic to handle missing `VERSION` files more gracefully, ensuring that outputs are always set and that the workflow can signal when a release should not proceed.

## Related Issue(s)

Fixes #40 